### PR TITLE
R api train

### DIFF
--- a/R-package/R/gbt.pred.R
+++ b/R-package/R/gbt.pred.R
@@ -29,8 +29,7 @@
 #' x.test <- runif(500, 0, 4)
 #' y.test <- rnorm(500, x.test, 1)
 #' 
-#' param <- list("learning_rate" = 0.03, "loss_function" = "mse", "nrounds"=2000)
-#' mod <- gbt.train(param, y, as.matrix(x))
+#' mod <- gbt.train(y, as.matrix(x))
 #' y.pred.1 <- gbt.pred( mod, as.matrix( x.test ) )
 #' 
 #' ## predict i overloaded

--- a/R-package/demo/Greedy_complexities_illustration.R
+++ b/R-package/demo/Greedy_complexities_illustration.R
@@ -22,22 +22,21 @@ y.test <- rnorm(500, 5* x.test, 1)
 
 
 # -- Train models --
-param <- list("learning_rate" = 0.01, "loss_function" = "mse", "nrounds"=2000)
-greedy_tree_mod <- gbt.train(param, y, x, verbose=T, greedy_complexities=F)
-greedy_complexities_mod <- gbt.train(param, y, x, verbose=T, greedy_complexities=T)
+greedy_tree_mod <- gbt.train(y, x, verbose=T, greedy_complexities=F)
+greedy_complexities_mod <- gbt.train(y, x, verbose=T, greedy_complexities=T)
 
 
 # -- Predict on test --
 # greedy tree
-y.pred <- predict( greedy_tree_mod, as.matrix( x.test ) )
+y.pred.vanilla <- predict( greedy_tree_mod, as.matrix( x.test ) )
 plot(x.test, y.test)
-points(x.test, y.pred, col="red")
-mean((y.test - y.pred)^2)
+points(x.test, y.pred.vanilla, col="red")
+mean((y.test - y.pred.vanilla)^2)
 # greedy complexities
-y.pred <- predict( greedy_complexities_mod, as.matrix( x.test ) )
-plot(x.test, y.test)
-points(x.test, y.pred, col="red")
-mean((y.test - y.pred)^2)
+y.pred.modified <- predict( greedy_complexities_mod, as.matrix( x.test ) )
+#plot(x.test, y.test)
+points(x.test, y.pred.modified, col="blue")
+mean((y.test - y.pred.modified)^2)
 
 
 # -- ILLUSTRATION --

--- a/R-package/demo/basic_train_test.R
+++ b/R-package/demo/basic_train_test.R
@@ -19,9 +19,8 @@ x.test <- as.matrix(age.test, ncol=1)
 y.test <- generateY(n, age.test, groups, sd)
 
 # train model
-param <- list("learning_rate" = 0.03, "loss_function" = "mse", "nrounds"=2000)
-mod <- gbt.train(param, y.train, x.train )
-mod$get_param()
+mod <- gbt.train(y.train, x.train, verbose=F, greedy_complexities=F)
+mod$get_param() # standard parameters
 pred.test <- predict( mod, x.test)
 plot(age.test,y.test, main="Predictions on test-data")
 points(age.test,pred.test,col=2)
@@ -31,6 +30,7 @@ mod.lm <- lm(y~., data=data.frame(y=y.train, x=x.train))
 pred.test.lm <- predict(mod.lm, newdata = data.frame(y=y.test, x=x.test))
 points(age.test, pred.test.lm, col="blue")
 
+# But what happens if we add 99 noise features?
 # multidim and noisy
 ndim = 99
 df <- data.frame(age=age)
@@ -44,7 +44,7 @@ x.test2 <- as.matrix(df.test)
 dim(x.train2); dim(x.test2)
 
 # build model on multidim designmatrix
-mod2 <- gbt.train(param, y.train, x.train2)
+mod2 <- gbt.train(y.train, x.train2, verbose=F, greedy_complexities=F)
 pred.test2 <- predict( mod2, x.test2 )
 points(age.test, pred.test2, col=3)
 

--- a/R-package/demo/boost_from_predictions.R
+++ b/R-package/demo/boost_from_predictions.R
@@ -17,8 +17,7 @@ x.test <- runif(500, 0, 4)
 y.test <- rnorm(500, x.test, 1)
 
 # First do standard boosting
-param <- list("learning_rate" = 0.03, "loss_function" = "mse", "nrounds"=2000)
-mod <- gbt.train(param, y, as.matrix(x), F, T)
+mod <- gbt.train(y, as.matrix(x), verbose=F)
 mod$get_num_trees()
 y.pred <- predict( mod, as.matrix( x.test ) )
 
@@ -28,15 +27,16 @@ points(x.test, y.pred, col=2)
 # Train a linear model
 lm.mod <- lm(y~., data.frame(y=y, x=x))
 
-# Assume L2 regularized with some strength --> preds scaled with 0.5
-preds <- 0.7* predict(lm.mod, data.frame(x))
-preds.test <- 0.7* predict(lm.mod, newdata=data.frame(x=x.test))
+# Assume L2 regularized with some strength --> preds scaled with 0.7
+lm.mod$coefficients["x"] <- lm.mod$coefficients["x"] * 0.7
+preds <- predict(lm.mod, data.frame(x))
+preds.test <- predict(lm.mod, newdata=data.frame(x=x.test))
 
 # How does this look like?
 points(x.test, preds.test, col=3)
 
 # Train from regularized linear model
-mod2 <- gbt.train(param, y, as.matrix(x), F, T, preds)
+mod2 <- gbt.train(y, as.matrix(x), verbose=F, previous_pred = preds)
 mod2$get_num_trees() # Smaller than boosting iterations for mod -- less added complexity needed
 
 y.pred2 <- predict( mod2, as.matrix(x.test))

--- a/R-package/demo/stock_market_classification.R
+++ b/R-package/demo/stock_market_classification.R
@@ -34,7 +34,7 @@ y.test <<- as.matrix(ifelse(Smarket[-ind_train, "Direction"]=="Up", 1, 0))
 # -- Model building --
 # gbtorch
 param <- list("learning_rate"=0.01, "loss_function"="logloss", "nrounds" = 5000)
-gbt.mod <- gbt.train(param, y.train, x.train)
+gbt.mod <- gbt.train(y.train, x.train, learning_rate = 0.01, loss_function = "logloss")
 gbt.mod$get_num_trees()
 
 # glm

--- a/R-package/man/gbt.pred.Rd
+++ b/R-package/man/gbt.pred.Rd
@@ -28,8 +28,7 @@ y <- rnorm(500, x, 1)
 x.test <- runif(500, 0, 4)
 y.test <- rnorm(500, x.test, 1)
 
-param <- list("learning_rate" = 0.03, "loss_function" = "mse", "nrounds"=2000)
-mod <- gbt.train(param, y, as.matrix(x))
+mod <- gbt.train(y, as.matrix(x))
 y.pred.1 <- gbt.pred( mod, as.matrix( x.test ) )
 
 ## predict i overloaded

--- a/R-package/man/gbt.train.Rd
+++ b/R-package/man/gbt.train.Rd
@@ -4,34 +4,26 @@
 \alias{gbt.train}
 \title{GBTorch Training.}
 \usage{
-gbt.train(param = list(), y, x, verbose = TRUE,
-  greedy_complexities = TRUE, previous_pred = NULL)
+gbt.train(y, x, learning_rate = 0.01, loss_function = "mse",
+  nrounds = 50000, verbose = FALSE, greedy_complexities = TRUE,
+  previous_pred = NULL)
 }
 \arguments{
-\item{param}{the list of parameters:
-
-1. Task Parameters
-
-\itemize{
-  \item \code{loss_function} specify the learning objective (loss function). Only pre-specified loss functions are currently supported.
-  \itemize{
-  \item \code{mse} regression with squared error loss (Default).
-  \item \code{logloss} logistic regression for binary classification, output score before logistic transformation.
-  }
-}
-
-2. Tree Booster Parameters
-
-\itemize{
-  \item \code{learning_rate} control the learning rate: scale the contribution of each tree by a factor of \code{0 < learning_rate < 1} when it is added to the current approximation. Lower value for \code{learning_rate} implies an increase in the number of boosting iterations: low \code{learning_rate} value means model more robust to overfitting but slower to compute. Default: 0.01
-  \item \code{nrounds} a just-in-case max number of boosting iterations. Default: 5000
-}}
-
 \item{y}{response vector for training. Must correspond to the design matrix \code{x}.}
 
 \item{x}{design matrix for training. Must be of type \code{matrix}.}
 
-\item{verbose}{Boolean: Enable boosting tracing information? Default: \code{TRUE}.}
+\item{learning_rate}{control the learning rate: scale the contribution of each tree by a factor of \code{0 < learning_rate < 1} when it is added to the current approximation. Lower value for \code{learning_rate} implies an increase in the number of boosting iterations: low \code{learning_rate} value means model more robust to overfitting but slower to compute. Default: 0.01}
+
+\item{loss_function}{specify the learning objective (loss function). Only pre-specified loss functions are currently supported.
+\itemize{
+\item \code{mse} regression with squared error loss (Default).
+\item \code{logloss} logistic regression for binary classification, output score before logistic transformation.
+}}
+
+\item{nrounds}{a just-in-case max number of boosting iterations. Default: 50000}
+
+\item{verbose}{Boolean: Enable boosting tracing information? Default: \code{FALSE}.}
 
 \item{greedy_complexities}{Boolean: \code{FALSE} means standard GTB, \code{TRUE} means greedy complexity tree-building. Default: \code{TRUE}.}
 
@@ -73,8 +65,7 @@ y <- rnorm(500, x, 1)
 x.test <- runif(500, 0, 4)
 y.test <- rnorm(500, x.test, 1)
 
-param <- list("learning_rate" = 0.03, "loss_function" = "mse", "nrounds"=2000)
-mod <- gbt.train(param, y, as.matrix(x))
+mod <- gbt.train(y, as.matrix(x))
 y.pred <- predict( mod, as.matrix( x.test ) )
 
 plot(x.test, y.test)

--- a/R-package/tests/testthat/test-errors.R
+++ b/R-package/tests/testthat/test-errors.R
@@ -11,13 +11,12 @@ test_that("gbt.train throws appropriate errors", {
     # Example
     x <- as.matrix(runif(500, 0, 4))
     y <- rnorm(500, x, 1)
-    param <- list("learning_rate" = 0.03, "loss_function" = "mse", "nrounds"=2000)
-    
+
     # x not a matrix
-    expect_error( gbt.train( y, "hello" ) )
+    expect_error( gbt.train( y, "not a matrix" ) )
     
     # y not a vector or 1-d matrix
-    expect_error( gbt.train( "hello", x ) )
+    expect_error( gbt.train( "not a vector", x ) )
     
     # x y different dim
     expect_error( gbt.train( rep(0, nrow(x)+1), x ) )

--- a/R-package/tests/testthat/test-errors.R
+++ b/R-package/tests/testthat/test-errors.R
@@ -6,7 +6,7 @@ test_that("gbt.train throws appropriate errors", {
     # Empty example, iteratively build until non-missing
     
     # Empty
-    expect_error( gbt.train( param, x, y ) )
+    expect_error( gbt.train( x, y ) )
     
     # Example
     x <- as.matrix(runif(500, 0, 4))
@@ -14,18 +14,18 @@ test_that("gbt.train throws appropriate errors", {
     param <- list("learning_rate" = 0.03, "loss_function" = "mse", "nrounds"=2000)
     
     # x not a matrix
-    expect_error( gbt.train( param, y, "hello" ) )
+    expect_error( gbt.train( y, "hello" ) )
     
     # y not a vector or 1-d matrix
-    expect_error( gbt.train( param, "hello", x ) )
+    expect_error( gbt.train( "hello", x ) )
     
     # x y different dim
-    expect_error( gbt.train( param, rep(0, nrow(x)+1), x ) )
+    expect_error( gbt.train( rep(0, nrow(x)+1), x ) )
     
     # param wrong values
-    expect_error( gbt.train( list("learning_rate" = 2, "loss_function" = "mse", "nrounds"=2000), y, x ) )
-    expect_error( gbt.train( list("learning_rate" = 0.5, "loss_function" = "not_a_function", "nrounds"=2000), y, x ) )
-    expect_error( gbt.train( list("learning_rate" = 0.5, "loss_function" = "mse", "nrounds"=c(1:5)), y, x ) )
-    expect_error( gbt.train( list("learning_rate" = 0.5, "loss_function" = "mse", "nrounds"=-1), y, x ) )
+    expect_error( gbt.train( y, x, learning_rate = 2) )
+    expect_error( gbt.train( y, x, loss_function = "not_a_function" ) )
+    expect_error( gbt.train( y, x, nrounds = c(1:5) ) )
+    expect_error( gbt.train( y, x, nrounds = -1) )
     
 })


### PR DESCRIPTION
### R-API Change

- Remove `param` as argument for `gbt.train`
- Elements of `param`: `loss_function`, `nrounds`, and `learning_rate` are set as ordinary parameters with default values
- Updated demoes and tests to be compatible with the new API