### PR TITLE
fixing verbose argument and cout to Rcpp cout, updating demos

### DIFF
--- a/R-package/R/gbt.train.R
+++ b/R-package/R/gbt.train.R
@@ -11,7 +11,7 @@
 #'   \item \code{logloss} logistic regression for binary classification, output score before logistic transformation.
 #'   }
 #' @param nrounds a just-in-case max number of boosting iterations. Default: 50000
-#' @param verbose Boolean: Enable boosting tracing information? Default: \code{FALSE}.
+#' @param verbose Enable boosting tracing information at i-th iteration? Default: \code{0}.
 #' @param greedy_complexities Boolean: \code{FALSE} means standard GTB, \code{TRUE} means greedy complexity tree-building. Default: \code{TRUE}.
 #' @param previous_pred prediction vector for training. Boosted training given predictions from another model.
 #'
@@ -67,7 +67,7 @@
 #' @export
 gbt.train <- function(y, x, learning_rate = 0.01,
                       loss_function = "mse", nrounds = 50000,
-                      verbose=FALSE, greedy_complexities=TRUE, 
+                      verbose=0, greedy_complexities=TRUE, 
                       previous_pred=NULL){
     
     error_messages <- c()
@@ -79,7 +79,7 @@ gbt.train <- function(y, x, learning_rate = 0.01,
         "\n Error: learning_rate must be a number between 0 and 1 \n",
         "\n Error: loss_function must be a valid loss function. See documentation for valid parameters \n",
         "\n Error: nrounds must be an integer >= 1 \n",
-        "\n Error: verbose must be of type logical with length 1",
+        "\n Error: verbose must be of type numeric with length 1",
         "\n Error: greedy_complexities must be of type logical with length 1",
         "\n Error: previous_pred must be a vector of type numeric",
         "\n Error: previous_pred must correspond to length of y"
@@ -132,13 +132,12 @@ gbt.train <- function(y, x, learning_rate = 0.01,
     
     
     # verbose
-    if(is.logical(verbose) && length(verbose)==1){
-        # ok
+    if(is.numeric(verbose) && length(verbose)==1){
+        #ok
     }else{
-        # error
         error_messages <- c(error_messages, error_messages_type[7])
     }
-    
+
     # greedy_complexities
     if(is.logical(greedy_complexities) && length(greedy_complexities)==1){
         #ok

--- a/R-package/demo/Greedy_complexities_illustration.R
+++ b/R-package/demo/Greedy_complexities_illustration.R
@@ -22,8 +22,8 @@ y.test <- rnorm(500, 5* x.test, 1)
 
 
 # -- Train models --
-greedy_tree_mod <- gbt.train(y, x, verbose=T, greedy_complexities=F)
-greedy_complexities_mod <- gbt.train(y, x, verbose=T, greedy_complexities=T)
+greedy_tree_mod <- gbt.train(y, x, verbose=1, greedy_complexities=F)
+greedy_complexities_mod <- gbt.train(y, x, verbose=1, greedy_complexities=T)
 
 
 # -- Predict on test --

--- a/R-package/demo/boost_from_predictions.R
+++ b/R-package/demo/boost_from_predictions.R
@@ -17,7 +17,7 @@ x.test <- runif(500, 0, 4)
 y.test <- rnorm(500, x.test, 1)
 
 # First do standard boosting
-mod <- gbt.train(y, as.matrix(x), verbose=F)
+mod <- gbt.train(y, as.matrix(x), verbose=0)
 mod$get_num_trees()
 y.pred <- predict( mod, as.matrix( x.test ) )
 
@@ -36,7 +36,7 @@ preds.test <- predict(lm.mod, newdata=data.frame(x=x.test))
 points(x.test, preds.test, col=3)
 
 # Train from regularized linear model
-mod2 <- gbt.train(y, as.matrix(x), verbose=F, previous_pred = preds)
+mod2 <- gbt.train(y, as.matrix(x), verbose=0, previous_pred = preds)
 mod2$get_num_trees() # Smaller than boosting iterations for mod -- less added complexity needed
 
 y.pred2 <- predict( mod2, as.matrix(x.test))

--- a/R-package/demo/gbt_high_dim.R
+++ b/R-package/demo/gbt_high_dim.R
@@ -21,7 +21,7 @@ y.test <- rnorm(n, x.test[,1], 1)
 
 # train model
 cat("Training a gbtorch model on one feature")
-mod <- gbt.train(y.train, x.train, verbose=T, greedy_complexities=T, learning_rate = 0.01)
+mod <- gbt.train(y.train, x.train, verbose=10, greedy_complexities=T, learning_rate = 0.01)
 mod$get_param() # standard parameters
 mod$get_num_trees()
 pred.test <- predict( mod, x.test)
@@ -62,7 +62,7 @@ df_sub <- data.frame(x1=x.train2[,1], x50=x.train2[,50], #x100=x.train2[,100],
 pairs(~., data=df_sub)
 
 cat("Training a second gbtorch model: give it a few seconds")
-mod2 <- gbt.train(y.train, x.train2, verbose=T, greedy_complexities=T)
+mod2 <- gbt.train(y.train, x.train2, verbose=1, greedy_complexities=T)
 pred.test2 <- predict( mod2, x.test2 )
 
 
@@ -127,7 +127,7 @@ cat("The dimensions of training and test:")
 dim(x.train3); dim(x.test3) 
 
 cat("Training a third gbtorch model: give it a few seconds")
-mod3 <- gbt.train(y.train, x.train3, verbose=T, greedy_complexities=T)
+mod3 <- gbt.train(y.train, x.train3, verbose=1, greedy_complexities=T)
 pred.test3 <- predict( mod3, x.test3 )
 
 # Training a GLMNET Lasso

--- a/R-package/man/gbt.train.Rd
+++ b/R-package/man/gbt.train.Rd
@@ -5,7 +5,7 @@
 \title{GBTorch Training.}
 \usage{
 gbt.train(y, x, learning_rate = 0.01, loss_function = "mse",
-  nrounds = 50000, verbose = FALSE, greedy_complexities = TRUE,
+  nrounds = 50000, verbose = 0, greedy_complexities = TRUE,
   previous_pred = NULL)
 }
 \arguments{
@@ -23,7 +23,7 @@ gbt.train(y, x, learning_rate = 0.01, loss_function = "mse",
 
 \item{nrounds}{a just-in-case max number of boosting iterations. Default: 50000}
 
-\item{verbose}{Boolean: Enable boosting tracing information? Default: \code{FALSE}.}
+\item{verbose}{Enable boosting tracing information at i-th iteration? Default: \code{0}.}
 
 \item{greedy_complexities}{Boolean: \code{FALSE} means standard GTB, \code{TRUE} means greedy complexity tree-building. Default: \code{TRUE}.}
 


### PR DESCRIPTION
- `std::cout` is not allowed, fixing this to Rcout to be compatible with R
- fixing `verbose` argument, not `true` `false` anymore, but of type int. 
- if `verbose > 0` then print at `boosting_iteration % verbose == 0`
- updating demos with proper use of verbose
- deleting two columns of verbose. Only iter - n_leaves - tr loss - ge loss