### PR TITLE
Adding functionality for Poisson regression

### DIFF
--- a/R-package/R/gbt.train.R
+++ b/R-package/R/gbt.train.R
@@ -9,6 +9,7 @@
 #'   \itemize{
 #'   \item \code{mse} regression with squared error loss (Default).
 #'   \item \code{logloss} logistic regression for binary classification, output score before logistic transformation.
+#'   \item \code{poisson} Poisson regression for count data using a log-link, output score before natural transformation. 
 #'   }
 #' @param nrounds a just-in-case max number of boosting iterations. Default: 50000
 #' @param verbose Enable boosting tracing information at i-th iteration? Default: \code{0}.
@@ -115,7 +116,7 @@ gbt.train <- function(y, x, learning_rate = 0.01,
     # loss function
     if(is.character(loss_function) && length(loss_function) == 1){
         if(
-            loss_function %in% c("mse", "logloss")
+            loss_function %in% c("mse", "logloss", "poisson")
         ){}else{
             error_messages <- c(error_messages, error_messages_type[5])
         }   

--- a/R-package/demo/poisson_regression.R
+++ b/R-package/demo/poisson_regression.R
@@ -1,0 +1,16 @@
+# Poisson regression
+# 09.11.2019
+# Berent Lunde
+
+data(mtcars)
+head(mtcars)
+dim(mtcars)
+
+y.train <- mtcars[,11]
+x.train <- as.matrix(mtcars[,-11])
+
+gbt_mod <- gbt.train(y.train, x.train, loss_function = "poisson", verbose=10)
+pred <- predict(gbt_mod, x.train) # predict log(lambda)
+pred_lambda <- exp(pred) # E[y] = lambda, y~Pois(lambda)
+
+plot(pred_lambda, y.train)

--- a/R-package/inst/include/loss_functions.hpp
+++ b/R-package/inst/include/loss_functions.hpp
@@ -17,8 +17,14 @@ double loss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type, Tvec<dou
         }
         
     }else if(loss_type=="logloss"){
+        // LOGLOSS
         for(int i=0; i<n; i++){
             res += y[i]*w[i]*log(1.0+exp(-pred[i])) + (1.0-y[i]*w[i])*log(1.0 + exp(pred[i]));
+        }
+    }else if(loss_type=="poisson"){
+        // POISSON
+        for(int i=0; i<n; i++){
+            res += exp(pred[i]) - y[i]*w[i]*pred[i]; // skip normalizing factor log(y!)
         }
     }
     
@@ -40,6 +46,11 @@ Tvec<double> dloss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type){
         for(int i=0; i<n; i++){
             g[i] = ( exp(pred[i]) * (1.0-y[i]) - y[i] ) / ( 1.0 + exp(pred[i]) );
         }
+    }else if(loss_type == "poisson"){
+        // POISSON REG
+        for(int i=0; i<n; i++){
+            g[i] = exp(pred[i]) - y[i];
+        }
     }
     
     return g;
@@ -49,6 +60,7 @@ Tvec<double> ddloss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type="
     Tvec<double> h(n);
     
     if( loss_type == "mse" ){
+        // MSE
         for(int i=0; i<n; i++){
             h[i] = 2.0;
         }
@@ -56,6 +68,11 @@ Tvec<double> ddloss(Tvec<double> &y, Tvec<double> &pred, std::string loss_type="
         // LOGLOSS
         for(int i=0; i<n; i++){
             h[i] = exp(pred[i]) / ( (exp(pred[i])+1.0)*(exp(pred[i])+1.0) ) ;
+        }
+    }else if(loss_type == "poisson"){
+        // POISSON REG
+        for(int i=0; i<n; i++){
+            h[i] = exp(pred[i]);
         }
     }
     

--- a/R-package/man/gbt.train.Rd
+++ b/R-package/man/gbt.train.Rd
@@ -19,6 +19,7 @@ gbt.train(y, x, learning_rate = 0.01, loss_function = "mse",
 \itemize{
 \item \code{mse} regression with squared error loss (Default).
 \item \code{logloss} logistic regression for binary classification, output score before logistic transformation.
+\item \code{poisson} Poisson regression for count data using a log-link, output score before natural transformation. 
 }}
 
 \item{nrounds}{a just-in-case max number of boosting iterations. Default: 50000}

--- a/R-package/src/gbtorch.cpp
+++ b/R-package/src/gbtorch.cpp
@@ -74,6 +74,9 @@ double ENSEMBLE::initial_prediction(Tvec<double> &y, std::string loss_function, 
     }else if(loss_function=="logloss"){
         double pred_g_transform = (y*w).sum()/n; // naive probability
         pred = log(pred_g_transform) - log(1 - pred_g_transform);
+    }else if(loss_function=="poisson"){
+        double pred_g_transform = (y*w).sum()/n; // naive intensity
+        pred = log(pred_g_transform);
     }
     
     return pred;


### PR DESCRIPTION
Poisson regression using the canoncial link (log) is implemented.
Notes:

- negative log-likelihood without $log(y!)$ scaling
- link function is log, i.e. $\hat{\lambda} = exp{\hat{y}}$
- example needed

Maybe add a dataset for Poisson regression?