### PR TITLE
Empirical cdf for max of max cir

### DIFF
--- a/R-package/R/gbt.train.R
+++ b/R-package/R/gbt.train.R
@@ -18,6 +18,7 @@
 #' @param greedy_complexities Boolean: \code{FALSE} means standard GTB, \code{TRUE} means greedy complexity tree-building. Default: \code{TRUE}.
 #' @param previous_pred prediction vector for training. Boosted training given predictions from another model.
 #' @param weights weights vector for scaling contributions of individual observations. Default \code{NULL} (the unit vector).
+#' @param force_continued_learning Boolean: \code{FALSE} (default) stops at information stopping criterion, \code{TRUE} stops at \code{nround} iterations.
 #'
 #' @details
 #' These are the training functions for \code{gbtorch}.
@@ -73,7 +74,8 @@ gbt.train <- function(y, x, learning_rate = 0.01,
                       loss_function = "mse", nrounds = 50000,
                       verbose=0, greedy_complexities=TRUE, 
                       previous_pred=NULL,
-                      weights = NULL){
+                      weights = NULL,
+                      force_continued_learning=FALSE){
     
     error_messages <- c()
     error_messages_type <- c(
@@ -87,7 +89,8 @@ gbt.train <- function(y, x, learning_rate = 0.01,
         "\n Error: verbose must be of type numeric with length 1",
         "\n Error: greedy_complexities must be of type logical with length 1",
         "\n Error: previous_pred must be a vector of type numeric",
-        "\n Error: previous_pred must correspond to length of y"
+        "\n Error: previous_pred must correspond to length of y",
+        "\n Error: force_continued_learning must be of type logical with length 1"
     )
     # Check y, x
     if(!is.vector(y, mode="numeric")){
@@ -162,6 +165,14 @@ gbt.train <- function(y, x, learning_rate = 0.01,
             error_messages <- c(error_messages, error_messages_type[10])
     }
     
+    # force_continued_learning
+    if(is.logical(force_continued_learning) && length(force_continued_learning)==1){
+        #ok
+    }else{
+        # error
+        error_messages <- c(error_messages, error_messages_type[11])
+    }
+    
     # Any error messages?
     if(length(error_messages)>0)
         stop(error_messages)
@@ -181,7 +192,7 @@ gbt.train <- function(y, x, learning_rate = 0.01,
     if(is.null(previous_pred)){
         
         # train from scratch
-        mod$train(y,x, verbose, greedy_complexities, weights)   
+        mod$train(y,x, verbose, greedy_complexities, force_continued_learning, weights)   
     }else{
         
         # train from previous predictions

--- a/R-package/inst/include/cir.hpp
+++ b/R-package/inst/include/cir.hpp
@@ -13,7 +13,7 @@
  */
 Tvec<double> cir_sim_vec(int m)
 {
-    double EPS = 1e-15;
+    double EPS = 1e-12;
     
     // Find original time of sim: assumption equidistant steps on u\in(0,1)
     double delta_time = 1.0 / ( m+1.0 );
@@ -51,11 +51,11 @@ Tvec<double> cir_sim_vec(int m)
 
 /*
  * cir_sim_mat:
- * Returns 100 by 100 cir simulations
+ * Returns 1000 by 1000 cir simulations
  */
 Tmat<double> cir_sim_mat()
 {
-    int n=1000, m=1000;
+    int n=100, m=200;
     Tmat<double> res(n, m);
     
     for(int i=0; i<n; i++){
@@ -164,7 +164,7 @@ Tvec<double> rmax_cir(const Tvec<double>& u, const Tmat<double>& cir_sim)
     Tvec<double> max_cir_obs(nsims);
     
     if(nsplits < simsplits){
-        double EPS = 1e-7;
+        double EPS = 1e-12;
         //int nsplits = u.size();
         
         // Transform interval: 0.5*log( (b*(1-a)) / (a*(1-b)) )

--- a/R-package/inst/include/cir.hpp
+++ b/R-package/inst/include/cir.hpp
@@ -75,7 +75,7 @@ Tmat<double> cir_sim_mat()
 Tmat<double> interpolate_cir(const Tvec<double>&u, const Tmat<double>& cir_sim)
 {
     // cir long-term mean is 2.0 -- but do not use this! 
-    double EPS = 1e-7;
+    double EPS = 1e-12;
     int cir_obs = cir_sim.cols();
     int n_timesteps = u.size();
     int n_sim = cir_sim.rows();

--- a/R-package/inst/include/cir.hpp
+++ b/R-package/inst/include/cir.hpp
@@ -53,13 +53,13 @@ Tvec<double> cir_sim_vec(int m)
  * cir_sim_mat:
  * Returns 1000 by 1000 cir simulations
  */
-Tmat<double> cir_sim_mat()
+Tmat<double> cir_sim_mat(int nsim, int nobs)
 {
-    int n=100, m=200;
-    Tmat<double> res(n, m);
+    //int n=100, m=200;
+    Tmat<double> res(nsim, nobs);
     
-    for(int i=0; i<n; i++){
-        res.row(i) = cir_sim_vec(m);
+    for(int i=0; i<nsim; i++){
+        res.row(i) = cir_sim_vec(nobs);
     }
     
     return res;

--- a/R-package/man/gbt.train.Rd
+++ b/R-package/man/gbt.train.Rd
@@ -6,7 +6,8 @@
 \usage{
 gbt.train(y, x, learning_rate = 0.01, loss_function = "mse",
   nrounds = 50000, verbose = 0, greedy_complexities = TRUE,
-  previous_pred = NULL, weights = NULL)
+  previous_pred = NULL, weights = NULL,
+  force_continued_learning = FALSE)
 }
 \arguments{
 \item{y}{response vector for training. Must correspond to the design matrix \code{x}.}
@@ -33,6 +34,8 @@ gbt.train(y, x, learning_rate = 0.01, loss_function = "mse",
 \item{previous_pred}{prediction vector for training. Boosted training given predictions from another model.}
 
 \item{weights}{weights vector for scaling contributions of individual observations. Default \code{NULL} (the unit vector).}
+
+\item{force_continued_learning}{Boolean: \code{FALSE} (default) stops at information stopping criterion, \code{TRUE} stops at \code{nround} iterations.}
 }
 \value{
 An object of class \code{ENSEMBLE} with the following elements:

--- a/R-package/src/gbtorch.cpp
+++ b/R-package/src/gbtorch.cpp
@@ -27,7 +27,8 @@ public:
     void set_param(Rcpp::List par_list);
     Rcpp::List get_param();
     double initial_prediction(Tvec<double> &y, std::string loss_function, Tvec<double> &w);
-    void train(Tvec<double> &y, Tmat<double> &X, int verbose, bool greedy_complexities, Tvec<double> &w);
+    void train(Tvec<double> &y, Tmat<double> &X, int verbose, bool greedy_complexities,
+               bool force_continued_learning, Tvec<double> &w);
     void train_from_preds(Tvec<double> &pred, Tvec<double> &y, Tmat<double> &X, int verbose, bool greedy_complexities, Tvec<double> &w);
     Tvec<double> predict(Tmat<double> &X);
     Tvec<double> predict2(Tmat<double> &X, int num_trees);
@@ -89,12 +90,13 @@ double ENSEMBLE::initial_prediction(Tvec<double> &y, std::string loss_function, 
 }
 
 
-void ENSEMBLE::train(Tvec<double> &y, Tmat<double> &X, int verbose, bool greedy_complexities, Tvec<double> &w){
+void ENSEMBLE::train(Tvec<double> &y, Tmat<double> &X, int verbose, bool greedy_complexities, 
+                     bool force_continued_learning, Tvec<double> &w){
     // Set init -- mean
     int MAXITER = param["nrounds"];
     int n = y.size(); 
     //int m = X.size();
-    double EPS = -1E-12;
+    double EPS = 1E-12;
     double expected_loss;
     double learning_rate_set = this->learning_rate;
     Tvec<double> pred(n), g(n), h(n);
@@ -162,13 +164,30 @@ void ENSEMBLE::train(Tvec<double> &y, Tmat<double> &X, int verbose, bool greedy_
             }
         }
         
+        // Stopping criteria 
+        // Check for continued learning
+        if(!force_continued_learning){
+            
+            // No forced learning
+            // Check criterion
+            if(expected_loss > EPS){
+                break;
+            }
+            
+        }
         
+        // Passed criterion or force passed: Update ensemble
+        current_tree->next_tree = new_tree;
+        current_tree = new_tree;
+        
+        /*
         if(expected_loss < EPS){ // && NUM_BINTREE_CONSECUTIVE < MAX_NUM_BINTREE_CONSECUTIVE){
             current_tree->next_tree = new_tree;
             current_tree = new_tree;
         }else{
             break;
         }
+         */
     }
 }
 

--- a/R-package/src/gbtorch.cpp
+++ b/R-package/src/gbtorch.cpp
@@ -95,7 +95,7 @@ void ENSEMBLE::train(Tvec<double> &y, Tmat<double> &X, int verbose, bool greedy_
     // Set init -- mean
     int MAXITER = param["nrounds"];
     int n = y.size(); 
-    //int m = X.size();
+    int m = X.cols();
     double EPS = 1E-12;
     double expected_loss;
     double learning_rate_set = this->learning_rate;
@@ -107,7 +107,9 @@ void ENSEMBLE::train(Tvec<double> &y, Tmat<double> &X, int verbose, bool greedy_
     this->initial_score = loss(y, pred, param["loss_function"], w); //(y - pred).squaredNorm() / n;
     
     // Prepare cir matrix
-    Tmat<double> cir_sim = cir_sim_mat();
+    // PARAMETERS FOR CIR CONTROL: Choose nsim and nobs by user
+    // Default to nsim=100 nobs=100
+    Tmat<double> cir_sim = cir_sim_mat(100, 100);
     
     // First tree
     g = dloss(y, pred, param["loss_function"]) * w;
@@ -195,7 +197,7 @@ void ENSEMBLE::train_from_preds(Tvec<double> &pred, Tvec<double> &y, Tmat<double
     // Set init -- mean
     int MAXITER = param["nrounds"];
     int n = y.size(); 
-    //int m = X.size();
+    int m = X.cols();
     double EPS = -1E-12;
     double expected_loss;
     double learning_rate_set = this->learning_rate;
@@ -209,7 +211,7 @@ void ENSEMBLE::train_from_preds(Tvec<double> &pred, Tvec<double> &y, Tmat<double
     this->initial_score = loss(y, pred, param["loss_function"], w); //(y - pred).squaredNorm() / n;
     
     // Prepare cir matrix
-    Tmat<double> cir_sim = cir_sim_mat();
+    Tmat<double> cir_sim = cir_sim_mat(std::max(2*m, 100), 100);
     
     // First tree
     g = dloss(y, pred, param["loss_function"])*w;


### PR DESCRIPTION
Adding methods for calculating the expected maximum of maximum cir observations. Implemented in an iterative fashion, so to not overload memory.

Removing the "gamma-trick" of estimating the distribution of max cir observations. 